### PR TITLE
[fix] Dockerfile build context

### DIFF
--- a/deploy/on_g1/Dockerfile
+++ b/deploy/on_g1/Dockerfile
@@ -70,7 +70,7 @@ RUN cd /catkin_ws/src && \
     find scripts -name "*.py" -exec sed -i 's|from Queue import|from queue import|g' {} \; && \
     find scripts -name "*.py" -exec sed -i 's|import Queue|import queue as Queue|g' {} \;
 
-COPY CLONE/deploy/onboard /catkin_ws/deploy_onboard
+COPY onboard /catkin_ws/deploy_onboard
 
 RUN sed -i '3s|cd nav/rosws/fastlio_localization|cd /catkin_ws|' /catkin_ws/deploy_onboard/localization_server.sh && \
     sed -i 's|cd \.\.|cd /catkin_ws|g' /catkin_ws/deploy_onboard/localization_server.sh && \

--- a/deploy/on_g1/docker-compose.yml
+++ b/deploy/on_g1/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   livox-driver:
     build:
-      context: ..  # 将构建上下文改为项目根目录
+      context: ..  # edit context dir as project root
       dockerfile: on_g1/Dockerfile
     image: livox-ros-driver:latest
     container_name: on-g1

--- a/deploy/on_g1/docker-compose.yml
+++ b/deploy/on_g1/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   livox-driver:
-    build: .
+    build:
+      context: ..  # 将构建上下文改为项目根目录
+      dockerfile: on_g1/Dockerfile
     image: livox-ros-driver:latest
     container_name: on-g1
     network_mode: host


### PR DESCRIPTION
In`deploy/on_g1/docker-compose.yml`, the build context is not correctly set, which cause failure `COPY` command when building image. The error message is 
```
failed to solve: failed to compute cache key: failed to calculate checksum of ref ac37f2bc-8d81-4cac-8430-5155da5cdbf6::j2o9ngsseasb32ckuyfzy4aq5: "/CLONE/deploy/onboard": not found
```
Please test with on the jetson orin nx on g1 as instructed in [Docker Readme](https://github.com/humanoid-clone/CLONE/blob/main/deploy/Docker_README.md)

```
cd deploy/on_g1/
docker compose up
```